### PR TITLE
Log axes example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,38 @@ from cosmoplots import figure_defs
 
 axes_size = figure_defs.set_rcparams_aip(plt.rcParams, num_cols=1, ls="thin")
 ```
+
+## `change_log_axis_base`
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+import cosmoplots
+
+axes_size = cosmoplots.set_rcparams_aip(plt.rcParams, num_cols=1, ls="thin")
+a = np.exp(np.linspace(-3, 5, 100))
+# 1 --- Semilogx
+fig = plt.figure()
+ax = fig.add_axes(axes_size)
+base = 2  # Default is 10, but 2 works equally well
+cosmoplots.change_log_axis_base(ax, "x", base=base)
+# Do plotting ...
+# If you use "plot", the change_log_axis_base can be called at the top (along with add_axes
+# etc.), but using loglog, semilogx, semilogy will re-set, and the change_log_axis_base
+# function must be called again.
+ax.plot(a)
+plt.show()
+
+# 2 --- Semilogy
+fig = plt.figure()
+ax = fig.add_axes(axes_size)
+cosmoplots.change_log_axis_base(ax, "y")
+# Do plotting ...
+# If you use "plot", the change_log_axis_base can be called at the top (along with add_axes
+# etc.), but using loglog, semilogx, semilogy will re-set, and the change_log_axis_base
+# function must be called again.
+ax.semilogy(a)
+cosmoplots.change_log_axis_base(ax, "y")  # Commenting out this result in the default base10 ticks
+plt.show()
+```
+

--- a/cosmoplots/__init__.py
+++ b/cosmoplots/__init__.py
@@ -1,2 +1,4 @@
 from .figure_defs import *
 from .axes import *
+
+__version__ = "0.1.1"

--- a/cosmoplots/axes.py
+++ b/cosmoplots/axes.py
@@ -49,7 +49,7 @@ def change_log_axis_base(axes: plt.Axes, which: str, base: float = 10) -> plt.Ax
         f = getattr(axes, ax)
         f.set_major_formatter(
             ticker.FuncFormatter(
-                lambda x, _: "{:g}".format(x)
+                lambda x, _: r"${:g}$".format(x)
                 if np.log(x) / np.log(base) in [0, 1]
                 else r"$"
                 + str(base)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cosmoplots"
-version = "0.1.0"
+version = "0.1.1"
 description = "Routines to get a sane default configuration for production quality plots."
 homepage = "https://github.com/uit-cosmo/cosmoplots"
 authors = ["gregordecristoforo <gregor.decristoforo@gmail.com>"]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name="cosmoplots",
-    version="0.1.0",
+    version="0.1.1",
     description="Definitions for figures and plots using matplotlib",
     author="Gregor Decristoforo",
     author_email="gregor.decristoforo@uit.no",


### PR DESCRIPTION
Creates a patch release: bumps up the version from 0.1.0 to 0.1.1.

Fixes bug in the font used in `change_log_axis_base`, where text font was used rather than math/numeric font.

Add example use of function `change_log_axis_base`.