### PR TITLE
feat(tick-format): add min_exponent to figure_defs function

### DIFF
--- a/cosmoplots/figure_defs.py
+++ b/cosmoplots/figure_defs.py
@@ -129,6 +129,8 @@ def set_rcparams_dynamo(
     # All ticks point inward
     myParams["xtick.direction"] = "in"
     myParams["ytick.direction"] = "in"
+    # Make log axes use exponents only for values of 2 and higher
+    myParams["axes.formatter.min_exponent"] = 2
 
     return axes_size
 


### PR DESCRIPTION
This PR resolves #16.

- [ ] Update README
- [ ] Decide what to do with the current implementation using `cosmoplots.change_log_axis_base`? Deprecation warning? Remove it?