### PR TITLE
refactor(mplstyle): move figure definitions to mplstyle files

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,31 +61,28 @@ plt.show()
 ## `matplotlib` vs. `cosmoplots` defaults
 
 ```python
+import cosmoplots
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
-import cosmoplots
+
+def plot() -> None:
+    a = np.exp(np.linspace(-3, 5, 100))
+    fig = plt.figure()
+    ax = fig.add_subplot()
+    ax.set_xlabel("X Axis")
+    ax.set_ylabel("Y Axis")
+    ax.semilogy(a)
 
 # Matplotlib ------------------------------------------------------------------------- #
-a = np.exp(np.linspace(-3, 5, 100))
-fig = plt.figure()
-ax = fig.add_subplot()
-ax.set_xlabel("X Axis")
-ax.set_ylabel("Y Axis")
-ax.semilogy(a)
-# plt.savefig("assets/matplotlib.png")
-plt.show()
+with mpl.style.context("default"):
+    plot()
+    # plt.savefig("assets/matplotlib.png")
+    plt.show()
 
 # Cosmoplots ------------------------------------------------------------------------- #
 with mpl.style.context("cosmoplots.default"):
-    a = np.exp(np.linspace(-3, 5, 100))
-    fig = plt.figure()
-    ax = fig.add_axes(axes_size)
-    ax.set_xlabel("X Axis")
-    ax.set_ylabel("Y Axis")
-    cosmoplots.change_log_axis_base(ax, "y")
-    ax.semilogy(a)
-    # Commenting out the below line result in the default base10 ticks
-    cosmoplots.change_log_axis_base(ax, "y")
+    plot()
     # plt.savefig("assets/cosmoplots.png")
     plt.show()
 ```

--- a/README.md
+++ b/README.md
@@ -23,10 +23,15 @@ poetry install
 
 Set your `rcparams` before plotting in your code, for example:
 
-```Python
+```python
 import cosmoplots
+import matplotlib as mpl
 
-axes_size = cosmoplots.set_rcparams_dynamo(plt.rcParams, num_cols=1, ls="thin")
+# If you only want the default style
+mpl.style.use("cosmoplots.default")
+# If you want the two column style, combine it with the default. Setting it after is
+# important, since values from the default is overridden.
+mpl.style.use(["cosmoplots.default", "cosmoplots.two_columns"])
 ```
 
 ## `change_log_axis_base`
@@ -35,11 +40,12 @@ axes_size = cosmoplots.set_rcparams_dynamo(plt.rcParams, num_cols=1, ls="thin")
 import matplotlib.pyplot as plt
 import numpy as np
 import cosmoplots
+import matplotlib as mpl
 
-axes_size = cosmoplots.set_rcparams_dynamo(plt.rcParams, num_cols=1, ls="thin")
+mpl.style.use("cosmoplots.default")
 a = np.exp(np.linspace(-3, 5, 100))
 fig = plt.figure()
-ax = fig.add_axes(axes_size)
+ax = plt.gca()
 ax.set_xlabel("X Axis")
 ax.set_ylabel("Y Axis")
 base = 2  # Default is 10, but 2 works equally well
@@ -59,7 +65,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import cosmoplots
 
-# Matplotlib --------------------------------------------------------------------------- #
+# Matplotlib ------------------------------------------------------------------------- #
 a = np.exp(np.linspace(-3, 5, 100))
 fig = plt.figure()
 ax = fig.add_subplot()
@@ -69,19 +75,19 @@ ax.semilogy(a)
 # plt.savefig("assets/matplotlib.png")
 plt.show()
 
-# Cosmoplots --------------------------------------------------------------------------- #
-axes_size = cosmoplots.set_rcparams_dynamo(plt.rcParams, num_cols=1, ls="thin")
-a = np.exp(np.linspace(-3, 5, 100))
-fig = plt.figure()
-ax = fig.add_axes(axes_size)
-ax.set_xlabel("X Axis")
-ax.set_ylabel("Y Axis")
-cosmoplots.change_log_axis_base(ax, "y")
-ax.semilogy(a)
-# Commenting out the below line result in the default base10 ticks
-cosmoplots.change_log_axis_base(ax, "y")
-# plt.savefig("assets/cosmoplots.png")
-plt.show()
+# Cosmoplots ------------------------------------------------------------------------- #
+with mpl.style.context("cosmoplots.default"):
+    a = np.exp(np.linspace(-3, 5, 100))
+    fig = plt.figure()
+    ax = fig.add_axes(axes_size)
+    ax.set_xlabel("X Axis")
+    ax.set_ylabel("Y Axis")
+    cosmoplots.change_log_axis_base(ax, "y")
+    ax.semilogy(a)
+    # Commenting out the below line result in the default base10 ticks
+    cosmoplots.change_log_axis_base(ax, "y")
+    # plt.savefig("assets/cosmoplots.png")
+    plt.show()
 ```
 
 | `matplotlib` | `cosmoplots` |

--- a/cosmoplots/default.mplstyle
+++ b/cosmoplots/default.mplstyle
@@ -1,0 +1,45 @@
+# https://matplotlib.org/stable/tutorials/introductory/customizing.html#the-default-matplotlibrc-file
+
+# Figure size and dpi
+figure.dpi : 300
+figure.figsize : 3.37, 2.08277
+# Same result as returning the rectangle and use it in plt.figure().add_axes([...])
+figure.subplot.left : 0.2
+figure.subplot.right : 0.95
+figure.subplot.bottom : 0.2
+figure.subplot.top : 0.95
+
+# Figure legend
+legend.framealpha : 1.0
+legend.fancybox : False
+legend.edgecolor : "k"
+patch.linewidth : 0.5  # For legend box borders
+legend.handlelength : 1.45  # Show nice, even numbers for different line styles
+
+# Font and text
+text.usetex : True
+pdf.fonttype : 42
+font.family : "Times"
+font.size : 8
+axes.labelsize : 8
+legend.fontsize : 8
+
+# Line size and marker size
+lines.markersize : 2.25
+lines.linewidth : 0.75
+
+# Axes thickness
+axes.linewidth : 0.5
+# Enable minor ticks
+ytick.minor.visible : True
+xtick.minor.visible : True
+# Default ticks on both sides of the axes
+xtick.top : True
+xtick.bottom : True
+ytick.left : True
+ytick.right : True
+# All ticks point inward
+xtick.direction : "in"
+ytick.direction : "in"
+# Tick formatting in log scale
+axes.formatter.min_exponent : 2

--- a/cosmoplots/thick_line.mplstyle
+++ b/cosmoplots/thick_line.mplstyle
@@ -1,0 +1,3 @@
+# Thick lines
+
+lines.linewidth : 1.5

--- a/cosmoplots/two_columns.mplstyle
+++ b/cosmoplots/two_columns.mplstyle
@@ -1,0 +1,8 @@
+# The two-column version.
+
+figure.figsize : 6.74, 2.08277
+# Same result as returning the rectangle and use it in plt.figure().add_axes([...])
+figure.subplot.left : 0.1
+figure.subplot.right : 0.975
+figure.subplot.bottom : 0.2
+figure.subplot.top : 0.95


### PR DESCRIPTION
Creates three files, one default and two that overrides default values and that should be use along with the default to specify two-column plots and plots with thicker lines.

This replaces `cosmoplots.set_rcparams_dynamo`.

- [x] Update README.md