### PR TITLE
build(deps): bump version from 0.2.1 to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cosmoplots"
-version = "0.2.1"
+version = "0.3.0"
 description = "Routines to get a sane default configuration for production quality plots."
 homepage = "https://github.com/uit-cosmo/cosmoplots"
 authors = ["gregordecristoforo <gregor.decristoforo@gmail.com>"]


### PR DESCRIPTION
This PR publishes v0.3.0, where the new `mplstyle` file will be included, as well as a deprecation warning about the logarithm tick change function.