### PR TITLE
feat(combine): reads font from the "font.serif" matplotlib param by default

### DIFF
--- a/cosmoplots/concat.py
+++ b/cosmoplots/concat.py
@@ -41,7 +41,11 @@ class Combine:
         self._color = "black"
         self._ft: str = ".png"
         self._output = pathlib.Path(f"output{self._ft}")
-        self._dpi = int(plt.rcParams["savefig.dpi"])
+        self._dpi = (
+            plt.rcParams["savefig.dpi"]
+            if isinstance(plt.rcParams["savefig.dpi"], float)
+            else plt.rcParams["figure.dpi"]
+        )
         self._files: list[pathlib.Path] = []
         self._labels: list[str] = []
         self._w: int | None = None
@@ -151,14 +155,16 @@ class Combine:
             count += 1
         return characters
 
-    def save(self, output: pathlib.Path | str | None = None, dpi: int | None = None) -> None:
+    def save(
+        self, output: pathlib.Path | str | None = None, dpi: float | int | None = None
+    ) -> None:
         """Save the combined images as a png file.
 
         Parameters
         ----------
         output : pathlib.Path | str, optional
             Give the name of the output file, default is `output.png`.
-        dpi : int, optional
+        dpi : float | int, optional
             The resolution that the input files were saved with. Default is the same as
             the matplotlib savefig dpi.
         """

--- a/cosmoplots/concat.py
+++ b/cosmoplots/concat.py
@@ -93,7 +93,8 @@ class Combine:
             The type of font to use, default is Times New Roman. See `convert -list
             font` for a list of available fonts.
         fontsize : int, optional
-            The size of the font in pointsize. Default is `100`.
+            The size of the font in pointsize. Default is to use the "font.size" field
+            in the matplotlib rcParams.
         color : str, optional
             The color of the text. Default is `black`.
         """

--- a/cosmoplots/concat.py
+++ b/cosmoplots/concat.py
@@ -41,6 +41,7 @@ class Combine:
         self._color = "black"
         self._ft: str = ".png"
         self._output = pathlib.Path(f"output{self._ft}")
+        self._dpi = int(plt.rcParams["savefig.dpi"])
         self._files: list[pathlib.Path] = []
         self._labels: list[str] = []
         self._w: int | None = None
@@ -150,14 +151,18 @@ class Combine:
             count += 1
         return characters
 
-    def save(self, output: pathlib.Path | str | None = None) -> None:
+    def save(self, output: pathlib.Path | str | None = None, dpi: int | None = None) -> None:
         """Save the combined images as a png file.
 
         Parameters
         ----------
         output : pathlib.Path | str, optional
             Give the name of the output file, default is `output.png`.
+        dpi : int, optional
+            The resolution that the input files were saved with. Default is the same as
+            the matplotlib savefig dpi.
         """
+        self._dpi = dpi or self._dpi
         self._check_params_before_save(output)
         self._check_cli_available()
         self._run_subprocess()
@@ -220,7 +225,7 @@ class Combine:
                     "PixelsPerInch",
                     file,
                     "-density",
-                    "300",
+                    str(self._dpi),
                     "-font",
                     self._font,
                     "-pointsize",

--- a/tests/test_concat.py
+++ b/tests/test_concat.py
@@ -33,7 +33,8 @@ def test_convert_help() -> None:
 
 def test_help(capfd) -> None:
     """Test the `help` method."""
-    cosmoplots.Combine().help()
+    # By default, the '.ttf' file is specified, but that's hard to test against.
+    cosmoplots.Combine().using(font="Times-New-Roman").help()
     out, err = capfd.readouterr()
     help = (
         "To create images with labels:\n"

--- a/tests/test_concat.py
+++ b/tests/test_concat.py
@@ -34,6 +34,7 @@ def test_convert_help() -> None:
 def test_help(capfd) -> None:
     """Test the `help` method."""
     # By default, the '.ttf' file is specified, but that's hard to test against.
+    plt.rcParams["font.size"] = 100
     cosmoplots.Combine().using(font="Times-New-Roman").help()
     out, err = capfd.readouterr()
     help = (


### PR DESCRIPTION
This also adjusts the `convert` command to specify the DPI, allowing for much better control of the font size. The font size is now read from the matplotlib params, meaning pointsize 8 when used with the default cosmoplots style.