### PR TITLE
chore: ignore local mise config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Mise local config file
+.mise.local.toml


### PR DESCRIPTION
Ignores local config file for mise.
