### PR TITLE
Updated to support type hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,23 +24,21 @@ poetry install
 Set your `rcparams` before plotting in your code, for example:
 
 ```python
+import matplotlib.pyplot as plt
 import cosmoplots
-import matplotlib as mpl
-
 # If you only want the default style
-mpl.style.use("cosmoplots.default")
+plt.style.use(["cosmoplots.default"])
 ```
 
 ### Muliple subfigures
 To make a figure with multiple rows or columns, use `cosmoplots.figure_multiple_rows_columns`:
 ```python
-import matplotlib as mpl
 import matplotlib.pyplot as plt
+import cosmoplots
+plt.style.use(["cosmoplots.default"])
+
 import numpy as np
 
-import cosmoplots
-
-mpl.style.use(["cosmoplots.default"])
 rows = 1
 columns = 2
 
@@ -58,12 +56,10 @@ plt.show()
 
 ```python
 import matplotlib.pyplot as plt
-import numpy as np
 import cosmoplots
-import matplotlib as mpl
+plt.style.use(["cosmoplots.default"])
+import numpy as np
 
-# Setup
-mpl.style.use("cosmoplots.default")
 a = np.exp(np.linspace(-3, 1, 100))
 
 # Plotting
@@ -96,9 +92,8 @@ plt.show()
 ## `matplotlib` vs. `cosmoplots` defaults
 
 ```python
-import cosmoplots
-import matplotlib as mpl
 import matplotlib.pyplot as plt
+import cosmoplots
 import numpy as np
 
 def plot() -> None:
@@ -110,13 +105,13 @@ def plot() -> None:
     ax.semilogy(a)
 
 # Matplotlib ------------------------------------------------------------------------- #
-with mpl.style.context("default"):
+with plt.style.context("default"):
     plot()
     # plt.savefig("assets/matplotlib.png")
     plt.show()
 
 # Cosmoplots ------------------------------------------------------------------------- #
-with mpl.style.context("cosmoplots.default"):
+with plt.style.context("cosmoplots.default"):
     plot()
     # plt.savefig("assets/cosmoplots.png")
     plt.show()
@@ -137,8 +132,7 @@ The colors change gradually from bright to dark or vice versa.
 ```python
 import matplotlib.pyplot as plt
 import cosmoplots
-
-axes_size = cosmoplots.set_rcparams_dynamo(plt.rcParams, num_cols=1, ls="thin")
+plt.style.use(["cosmoplots.default"])
 
 
 color_list = cosmoplots.generate_hex_colors(5, 'viridis', show_swatch=True, ascending=True)
@@ -148,7 +142,7 @@ plt.savefig("./assets/hex_colors.png")
 print(color_list) #['#fde725', '#5ec962', '#21918c', '#3b528b', '#440154']
 
 fig = plt.figure()
-ax = fig.add_axes(axes_size)
+ax = plt.gca()
 for i, color in enumerate(color_list):
     ax.plot([1,2],[i,i+1], c = color)
 
@@ -174,13 +168,10 @@ A `help` method that prints the `imagemagick` commands that are used under the h
 also available.
 
 ```python
-import matplotlib as mpl
 import matplotlib.pyplot as plt
-import numpy as np
-
 import cosmoplots
-
-mpl.style.use("cosmoplots.default")
+plt.style.use("cosmoplots.default")
+import numpy as np
 
 
 def plot(i) -> None:

--- a/cosmoplots/axes.py
+++ b/cosmoplots/axes.py
@@ -2,6 +2,8 @@
 
 from typing import List, Tuple, Union
 import matplotlib as mpl
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib import ticker
@@ -14,7 +16,7 @@ def _convert_scale_name(scale: str, axis: str) -> str:
     return f"{axis}axis" if scale == "log" else "none"
 
 
-def _check_axes_scales(axes: plt.Axes) -> Tuple[List[str], str]:
+def _check_axes_scales(axes: Axes) -> Tuple[List[str], str]:
     xscale, yscale = axes.get_xscale(), axes.get_yscale()
     xs, ys = _convert_scale_name(xscale, "x"), _convert_scale_name(yscale, "y")
     if xs == "xaxis" and ys == "yaxis":
@@ -33,8 +35,8 @@ def _check_axes_scales(axes: plt.Axes) -> Tuple[List[str], str]:
 
 
 def change_log_axis_base(
-    axes: plt.Axes, which: Union[str, None] = None, base: float = 10
-) -> plt.Axes:
+    axes: Axes, which: Union[str, None] = None, base: float = 10
+) -> Axes:
     """Change the tick formatter to not use powers 0 and 1 in logarithmic plots.
 
     Change the logarithmic axis `10^0 -> 1` and `10^1 -> 10` (or the given base), i.e.
@@ -90,7 +92,7 @@ def change_log_axis_base(
         )
     return axes
 
-def figure_multiple_rows_columns(rows: int, columns: int):
+def figure_multiple_rows_columns(rows: int, columns: int) -> Tuple[Figure, List[Axes]]:
     """Returns a figure with axes which is appropriate for (rows, columns) subfigures.
 
     Parameters
@@ -108,15 +110,14 @@ def figure_multiple_rows_columns(rows: int, columns: int):
         A list of all the axes objects owned by the figure
     """
     fig = plt.figure(figsize = (columns*3.37, rows*2.08277))
-    axes = [None]*rows*columns
+    axes = []
     for c in range(columns):
         for r in range(rows):
-            index = r*columns + c
             left = (0.2)/columns + c/columns
             bottom = (0.2)/rows + (rows-1-r)/rows # Start at the top
             width = 0.75/columns
             height = 0.75/rows
-            axes[index]  = fig.add_axes([left, bottom, width, height])
+            axes.append(fig.add_axes((left, bottom, width, height)))
 
     return fig, axes
 

--- a/cosmoplots/axes.py
+++ b/cosmoplots/axes.py
@@ -1,7 +1,6 @@
 """Module for modifying the axis properties of plots."""
 
 from typing import List, Tuple, Union
-import matplotlib as mpl
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 import matplotlib.pyplot as plt


### PR DESCRIPTION
This fixes type hints I got in two instances:

1) README updated so we use the import sequence reccomended by matplotlib: https://matplotlib.org/stable/users/explain/customizing.html#distributing-styles

2) Importing Axes and Figure lets pyright understand the type of `figure_multiple_rows_columns` and provide correct hints.
See https://github.com/matplotlib/matplotlib/issues/26812 for discussion.