### PR TITLE
chore(concat): attempt to silence warning from magick

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ combining the plots using the `subfigure` environment in latex or similar is not
 option, this is easily done with [`imagemagick`](https://imagemagick.org/index.php) in a
 systematic way.
 
+> [!caution]
+>
+> This uses `imagemagick v7`.
+
 The `Combine` class within the `concat` module implements such procedures, and is also
 conveniently available from the `combine` function in `cosmoplots`.
 
@@ -196,7 +200,7 @@ plot(7)
 plot(8)
 plot(9)
 plot(10)
-# See `magick convert -list font` for all available fonts.
+# See `magick -list font` for all available fonts.
 figs = [f"./assets/{i}.png" for i in range(1, 11)]
 cosmoplots.combine(*figs).using(
     font="JetBrainsMonoNL-NFM-Medium",

--- a/tests/test_concat.py
+++ b/tests/test_concat.py
@@ -24,9 +24,9 @@ def plot() -> None:
     ax.semilogy(a)
 
 
-def test_magick_convert_help() -> None:
+def test_magick_help() -> None:
     """Test that ImageMagick's magick command is available."""
-    result = subprocess.check_output(["magick", "convert", "--help"])
+    result = subprocess.check_output(["magick", "--help"])
     out = "b'Version: ImageMagick'"
     assert str(result[:20]) == out
 
@@ -39,15 +39,15 @@ def test_help(capfd) -> None:
     out, err = capfd.readouterr()
     help = (
         "To create images with labels:\n"
-        "    magick convert in-a.png -font Times-New-Roman -pointsize 100 -draw \"gravity northwest fill black text 10.0,10.0 '(a)'\" a.png\n"
-        "    magick convert in-b.png -font Times-New-Roman -pointsize 100 -draw \"gravity northwest fill black text 10.0,10.0 '(b)'\" b.png\n"
-        "    magick convert in-c.png -font Times-New-Roman -pointsize 100 -draw \"gravity northwest fill black text 10.0,10.0 '(c)'\" c.png\n"
-        "    magick convert in-d.png -font Times-New-Roman -pointsize 100 -draw \"gravity northwest fill black text 10.0,10.0 '(d)'\" d.png\n"
+        "    magick in-a.png -font Times-New-Roman -pointsize 100 -draw \"gravity northwest fill black text 10.0,10.0 '(a)'\" a.png\n"
+        "    magick in-b.png -font Times-New-Roman -pointsize 100 -draw \"gravity northwest fill black text 10.0,10.0 '(b)'\" b.png\n"
+        "    magick in-c.png -font Times-New-Roman -pointsize 100 -draw \"gravity northwest fill black text 10.0,10.0 '(c)'\" c.png\n"
+        "    magick in-d.png -font Times-New-Roman -pointsize 100 -draw \"gravity northwest fill black text 10.0,10.0 '(d)'\" d.png\n"
         "Then to combine them horizontally:\n"
-        "    magick convert +append a.png b.png ab.png\n"
-        "    magick convert +append c.png d.png cd.png\n"
+        "    magick a.png b.png +append ab.png\n"
+        "    magick c.png d.png +append cd.png\n"
         "And finally stack them vertically:\n"
-        "    magick convert -append ab.png cd.png out.png\n"
+        "    magick ab.png cd.png -append out.png\n"
         "Optionally delete all temporary files:\n"
         "    rm a.png b.png c.png d.png ab.png cd.png\n"
     )

--- a/tests/test_concat.py
+++ b/tests/test_concat.py
@@ -24,11 +24,11 @@ def plot() -> None:
     ax.semilogy(a)
 
 
-def test_magick_help() -> None:
+def test_magick_version() -> None:
     """Test that ImageMagick's magick command is available."""
-    result = subprocess.check_output(["magick", "--help"])
-    out = "b'Version: ImageMagick'"
-    assert str(result[:20]) == out
+    result = subprocess.check_output(["magick", "--version"])
+    out = "b'Version: ImageMagick 7'"
+    assert str(result[:22]) == out
 
 
 def test_help(capfd) -> None:


### PR DESCRIPTION
The `magick` command is more strict on the order of arguments passed in as compared to `convert`. See https://github.com/ImageMagick/ImageMagick/discussions/7366#discussioncomment-10627878